### PR TITLE
Update checkin for i2c refactor

### DIFF
--- a/broker/protobuf_autoresponders.js
+++ b/broker/protobuf_autoresponders.js
@@ -11,8 +11,7 @@ const requestToResponseMap = {
       response: 'RESPONSE_OK',
       totalGpioPins: 20,
       totalAnalogPins: 4,
-      referenceVoltage: 2.5,
-      totalI2cPorts: 1
+      referenceVoltage: 2.5
     }
   }
 }


### PR DESCRIPTION
Updates the checkin autoresponder to remove `totalI2cPorts` field (which has since been refactored out of checkin.proto)